### PR TITLE
use full name for git branch

### DIFF
--- a/.bash_login.prompt
+++ b/.bash_login.prompt
@@ -47,7 +47,7 @@ function parse_git_dirty {
 
 # $1 = git status --short --branch 2>&1
 function parse_git_branch {
-  branch=$(git br --no-color 2> /dev/null | sed -n '/^\*/p' | sed -e "s/^\* \(.*\)/\1/")
+  branch=$(git branch --no-color 2> /dev/null | sed -n '/^\*/p' | sed -e "s/^\* \(.*\)/\1/")
   if [[ $branch != "" ]]
   then
     # 原 approximately means "original", hence master


### PR DESCRIPTION
Your version was using a nonstandard alias for `git branch`. Tsk, tsk.
